### PR TITLE
sqLite + node.js bugfix

### DIFF
--- a/Types/DbClient/SqLiteNjClient/SqLiteNjCommand.js
+++ b/Types/DbClient/SqLiteNjClient/SqLiteNjCommand.js
@@ -12,9 +12,28 @@ $data.Class.define('$data.dbClient.sqLiteNJClient.SqLiteNjCommand', $data.dbClie
     },
     executeQuery: function (callback) {
         callback = $data.typeSystem.createCallbackSetting(callback);
-        this.exec(this.query, this.parameters, callback.success, callback.error);
+		if (!this.connection._executeHelper.isRunning){
+			//console.log('not running, executing query');
+			this.exec(this.query, this.parameters, callback.success, callback.error);
+		} else {
+			//console.log('running, queue query');
+			this.connection._executeHelper.queue.push({
+				that : this,
+				callback : callback
+			});			
+		}
     },
+	_executeNext : function(){
+		//console.log('running, dequeue query');
+		var next = this.connection._executeHelper.queue.shift();
+		var that = next.that;
+		var callback = next.callback;
+		setTimeout(function(){
+			that.exec(that.query, that.parameters, callback.success, callback.error);
+		},0);
+	},
     exec: function (query, parameters, callback, errorhandler) {
+		this.connection._executeHelper.isRunning = true;
         if (!this.connection.isOpen()) {
             this.connection.open();
         }
@@ -31,19 +50,45 @@ $data.Class.define('$data.dbClient.sqLiteNJClient.SqLiteNjCommand', $data.dbClie
         var provider = this;
         var results = [];
         var remainingCommands = 0;
+		var isErrorHappened = false;
         var decClb = function () {
             if (--remainingCommands == 0) {
-                provider.connection.database.exec('COMMIT');
-                callback(single ? results[0] : results);
+				if(isErrorHappened){
+					provider.connection.database.exec('ROLLBACK');
+					if (provider.connection._executeHelper.queue.length){
+						provider._executeNext();
+					} else {
+						provider.connection._executeHelper.isRunning = false;
+						//console.log('finish queque');
+					}
+				} else {
+					provider.connection.database.exec('COMMIT');
+					try {
+						callback(single ? results[0] : results);
+					} finally {
+						if (provider.connection._executeHelper.queue.length){
+							provider._executeNext();
+						} else {
+							provider.connection._executeHelper.isRunning = false;
+							//console.log('finish queque');
+						}
+					}
+				}
             }
         };
         provider.connection.database.exec('BEGIN');
+		remainingCommands = query.length;
         query.forEach(function (q, i) {
-            remainingCommands++;
             if (q) {
                 var sqlClb = function (error, rows) {
                     if (error != null) {
-                        errorhandler(error);
+						try {
+							isErrorHappened = true;
+							errorhandler(error);
+						} finally {
+							//console.log('error',error,q);
+							decClb();
+						}
                         return;
                     }
                     if (this.lastID) {

--- a/Types/DbClient/SqLiteNjClient/SqLiteNjConnection.js
+++ b/Types/DbClient/SqLiteNjClient/SqLiteNjConnection.js
@@ -18,5 +18,11 @@ $data.Class.define('$data.dbClient.sqLiteNJClient.SqLiteNjConnection', $data.dbC
     createCommand: function (queryStr, params) {
         var cmd = new $data.dbClient.sqLiteNJClient.SqLiteNjCommand(this, queryStr, params);
         return cmd;
-    }
+    },
+	_executeHelper : {
+		value : {
+			isRunning : false,
+			queue : []
+		}
+	},
 }, null);

--- a/Types/StorageProviders/SqLite/SqLiteCompiler.js
+++ b/Types/StorageProviders/SqLite/SqLiteCompiler.js
@@ -1,4 +1,4 @@
-var SqlStatementBlocks = {
+$C('$data.sqLite.SqlStatementBlocks', null,null,null,{
     beginGroup: "(",
     endGroup: ")",
     nameSeparator: ".",
@@ -14,7 +14,8 @@ var SqlStatementBlocks = {
     scalarFieldName: 'd',
     rowIdName: 'rowid$$',
     count: 'select count(*) cnt from ('
-};
+});
+
 $C('$data.sqLite.SqlBuilder', $data.queryBuilder, null, {
     constructor: function (sets, context) {
         this.sets = sets;
@@ -59,7 +60,7 @@ $C('$data.sqLite.SqlCompiler', $data.Expressions.EntityExpressionVisitor, null, 
         var countPart = sqlBuilder.getTextPart('count');
         if (countPart !== undefined) {
             sqlBuilder.selectedFragment.text = countPart.text + sqlBuilder.selectedFragment.text;
-            sqlBuilder.addText(SqlStatementBlocks.endGroup);
+            sqlBuilder.addText($data.sqLite.SqlStatementBlocks.endGroup);
             sqlBuilder.selectedFragment.params = sqlBuilder.selectedFragment.params.concat(countPart.params);
         }
         sqlBuilder.resetModelBinderProperty();
@@ -72,12 +73,12 @@ $C('$data.sqLite.SqlCompiler', $data.Expressions.EntityExpressionVisitor, null, 
     VisitCountExpression: function (expression, sqlBuilder) {
         this.Visit(expression.source, sqlBuilder);
         sqlBuilder.selectTextPart('count');
-        sqlBuilder.addText(SqlStatementBlocks.count);
+        sqlBuilder.addText($data.sqLite.SqlStatementBlocks.count);
     },
     VisitFilterExpression: function (expression, sqlBuilder) {
         this.Visit(expression.source, sqlBuilder);
         sqlBuilder.selectTextPart('filter');
-        sqlBuilder.addText(SqlStatementBlocks.where);
+        sqlBuilder.addText($data.sqLite.SqlStatementBlocks.where);
         var filterCompiler = $data.sqLite.SqlFilterCompiler.create();
         filterCompiler.Visit(expression.selector, sqlBuilder);
         return expression;
@@ -87,10 +88,10 @@ $C('$data.sqLite.SqlCompiler', $data.Expressions.EntityExpressionVisitor, null, 
         this.Visit(expression.source, sqlBuilder);
         sqlBuilder.selectTextPart('order');
         if (this.addOrders) {
-            sqlBuilder.addText(SqlStatementBlocks.valueSeparator);
+            sqlBuilder.addText($data.sqLite.SqlStatementBlocks.valueSeparator);
         } else {
             this.addOrders = true;
-            sqlBuilder.addText(SqlStatementBlocks.order);
+            sqlBuilder.addText($data.sqLite.SqlStatementBlocks.order);
         }
         var orderCompiler = $data.sqLite.SqlOrderCompiler.create();
         orderCompiler.Visit(expression, sqlBuilder);
@@ -103,10 +104,10 @@ $C('$data.sqLite.SqlCompiler', $data.Expressions.EntityExpressionVisitor, null, 
         switch (expression.nodeType) {
             case $data.Expressions.ExpressionType.Skip:
                 sqlBuilder.selectTextPart('skip');
-                sqlBuilder.addText(SqlStatementBlocks.skip); break;
+                sqlBuilder.addText($data.sqLite.SqlStatementBlocks.skip); break;
             case $data.Expressions.ExpressionType.Take:
                 sqlBuilder.selectTextPart('take');
-                sqlBuilder.addText(SqlStatementBlocks.take); break;
+                sqlBuilder.addText($data.sqLite.SqlStatementBlocks.take); break;
             default: Guard.raise("Not supported nodeType"); break;
         }
         var pagingCompiler = $data.sqLite.SqlPagingCompiler.create();
@@ -117,13 +118,13 @@ $C('$data.sqLite.SqlCompiler', $data.Expressions.EntityExpressionVisitor, null, 
         this.Visit(expression.source, sqlBuilder);
         sqlBuilder.selectTextPart('projection');
         this.hasProjection = true;
-        sqlBuilder.addText(SqlStatementBlocks.select);
+        sqlBuilder.addText($data.sqLite.SqlStatementBlocks.select);
         var projectonCompiler = $data.sqLite.SqlProjectionCompiler.create();
         projectonCompiler.Visit(expression, sqlBuilder);
     },
     VisitEntitySetExpression: function (expression, sqlBuilder) {
         sqlBuilder.selectTextPart('from');
-        sqlBuilder.addText(SqlStatementBlocks.from);
+        sqlBuilder.addText($data.sqLite.SqlStatementBlocks.from);
         sqlBuilder.sets.forEach(function (es, setIndex) {
 
             if (setIndex > 0) {
@@ -157,19 +158,19 @@ $C('$data.sqLite.SqlCompiler', $data.Expressions.EntityExpressionVisitor, null, 
         sqlBuilder.selectTextPart('projection');
         var needAlias = this.infos.filter(function (i) { return i.IsMapped; }).length > 1;
         if (sqlBuilder.sets.length > 1) {
-            sqlBuilder.addText(SqlStatementBlocks.select);
+            sqlBuilder.addText($data.sqLite.SqlStatementBlocks.select);
             sqlBuilder.sets.forEach(function (set, masterIndex) {
 
                 if (this.infos[masterIndex].IsMapped) {
                     var alias = sqlBuilder.getExpressionAlias(set);
                     set.storageModel.PhysicalType.memberDefinitions.getPublicMappedProperties().forEach(function (memberDef, index) {
                         if (index > 0 || masterIndex > 0) {
-                            sqlBuilder.addText(SqlStatementBlocks.valueSeparator);
+                            sqlBuilder.addText($data.sqLite.SqlStatementBlocks.valueSeparator);
                         }
                         sqlBuilder.addText(alias + ".");
                         sqlBuilder.addText(memberDef.name);
                         if (needAlias) {
-                            sqlBuilder.addText(SqlStatementBlocks.as);
+                            sqlBuilder.addText($data.sqLite.SqlStatementBlocks.as);
                             sqlBuilder.addText(alias + "__" + memberDef.name);
                         }
                     }, this);

--- a/Types/StorageProviders/SqLite/SqlFilterCompiler.js
+++ b/Types/StorageProviders/SqLite/SqlFilterCompiler.js
@@ -7,9 +7,9 @@ $C('$data.sqLite.SqlFilterCompiler', $data.Expressions.EntityExpressionVisitor, 
         /// <param name="expression" type="$data.Expressions.SimpleBinaryExpression"></param>
         /// <param name="sqlBuilder" type="$data.sqLite.SqlBuilder"></param>
             sqlBuilder.addText(expression.resolution.mapTo);
-            sqlBuilder.addText(SqlStatementBlocks.beginGroup);
+            sqlBuilder.addText($data.sqLite.SqlStatementBlocks.beginGroup);
             this.Visit(expression.operand, sqlBuilder);
-            sqlBuilder.addText(SqlStatementBlocks.endGroup);
+            sqlBuilder.addText($data.sqLite.SqlStatementBlocks.endGroup);
     },
 
     VisitSimpleBinaryExpression: function (expression, sqlBuilder) {
@@ -20,7 +20,7 @@ $C('$data.sqLite.SqlFilterCompiler', $data.Expressions.EntityExpressionVisitor, 
         if (expression.nodeType == "arrayIndex") {
             this.Visit(expression.left, sqlBuilder);
         } else {
-            sqlBuilder.addText(SqlStatementBlocks.beginGroup);
+            sqlBuilder.addText($data.sqLite.SqlStatementBlocks.beginGroup);
 
             //check null filter
             if (expression.left instanceof $data.Expressions.EntityFieldExpression && expression.right instanceof $data.Expressions.ConstantExpression && expression.right.value === null) {
@@ -38,12 +38,12 @@ $C('$data.sqLite.SqlFilterCompiler', $data.Expressions.EntityExpressionVisitor, 
                     Guard.requireType("expression.right", expression.right, $data.Expressions.ConstantExpression);
                     var set = expression.right.value;
                     if (set instanceof Array) {
-                        sqlBuilder.addText(SqlStatementBlocks.beginGroup);
+                        sqlBuilder.addText($data.sqLite.SqlStatementBlocks.beginGroup);
                         set.forEach(function (item, i) {
-                            if (i > 0) sqlBuilder.addText(SqlStatementBlocks.valueSeparator);
+                            if (i > 0) sqlBuilder.addText($data.sqLite.SqlStatementBlocks.valueSeparator);
                             self.Visit(item, sqlBuilder);
                         });
-                        sqlBuilder.addText(SqlStatementBlocks.endGroup);
+                        sqlBuilder.addText($data.sqLite.SqlStatementBlocks.endGroup);
                     } else if (set instanceof $data.Queryable) {
                         sqlBuilder.addText("(SELECT d FROM (" + set.toTraceString().sqlText + "))");
                         //Guard.raise("Not yet... but coming!");
@@ -55,7 +55,7 @@ $C('$data.sqLite.SqlFilterCompiler', $data.Expressions.EntityExpressionVisitor, 
                 }
             }
             
-            sqlBuilder.addText(SqlStatementBlocks.endGroup);
+            sqlBuilder.addText($data.sqLite.SqlStatementBlocks.endGroup);
         }
     },
 
@@ -65,7 +65,7 @@ $C('$data.sqLite.SqlFilterCompiler', $data.Expressions.EntityExpressionVisitor, 
 
         var alias = sqlBuilder.getExpressionAlias(expression);
         sqlBuilder.addText(alias);
-        sqlBuilder.addText(SqlStatementBlocks.nameSeparator);
+        sqlBuilder.addText($data.sqLite.SqlStatementBlocks.nameSeparator);
     },
     VisitEntityFieldOperationExpression: function (expression, sqlBuilder) {
         /// <param name="expression" type="$data.Expressions.EntityFieldOperationExpression"></param>
@@ -78,7 +78,7 @@ $C('$data.sqLite.SqlFilterCompiler', $data.Expressions.EntityExpressionVisitor, 
         var opName = opDefinition.mapTo || opDefinition.name;
 
         sqlBuilder.addText(opName);
-        sqlBuilder.addText(SqlStatementBlocks.beginGroup);
+        sqlBuilder.addText($data.sqLite.SqlStatementBlocks.beginGroup);
         if (opName === "like") {
             var builder = $data.sqLite.SqlBuilder.create([], sqlBuilder.entityContext);
             builder.selectTextPart("fragment");
@@ -102,7 +102,7 @@ $C('$data.sqLite.SqlFilterCompiler', $data.Expressions.EntityExpressionVisitor, 
             }, this);
         };
 
-        sqlBuilder.addText(SqlStatementBlocks.endGroup);
+        sqlBuilder.addText($data.sqLite.SqlStatementBlocks.endGroup);
     },
     VisitMemberInfoExpression: function (expression, sqlBuilder) {
         /// <param name="expression" type="$data.Expressions.MemberInfoExpression"></param>
@@ -118,14 +118,14 @@ $C('$data.sqLite.SqlFilterCompiler', $data.Expressions.EntityExpressionVisitor, 
             value = expression.value;
         }
         sqlBuilder.addParameter(value);
-        sqlBuilder.addText(SqlStatementBlocks.parameter);
+        sqlBuilder.addText($data.sqLite.SqlStatementBlocks.parameter);
     },
 
     VisitConstantExpression: function (expression, sqlBuilder) {
         //var typeNameHintFromValue = Container.getTypeName(expression.value);
         var value = sqlBuilder.entityContext.storageProvider.fieldConverter.toDb[Container.resolveName(Container.resolveType(expression.type))](expression.value);;
         sqlBuilder.addParameter(value);
-        sqlBuilder.addText(SqlStatementBlocks.parameter);
+        sqlBuilder.addText($data.sqLite.SqlStatementBlocks.parameter);
     },
 
     VisitEntityFieldExpression:function(expression, sqlBuilder){

--- a/Types/StorageProviders/SqLite/SqlOrderCompiler.js
+++ b/Types/StorageProviders/SqLite/SqlOrderCompiler.js
@@ -11,7 +11,7 @@ $C('$data.sqLite.SqlOrderCompiler', $data.Expressions.EntityExpressionVisitor, n
 
         var alias = sqlBuilder.getExpressionAlias(expression);
         sqlBuilder.addText(alias);
-        sqlBuilder.addText(SqlStatementBlocks.nameSeparator);
+        sqlBuilder.addText($data.sqLite.SqlStatementBlocks.nameSeparator);
     },
     VisitOrderExpression: function (expression, sqlBuilder) {
         this.Visit(expression.selector, sqlBuilder);

--- a/Types/StorageProviders/SqLite/SqlPagingCompiler.js
+++ b/Types/StorageProviders/SqLite/SqlPagingCompiler.js
@@ -10,6 +10,6 @@ $C('$data.sqLite.SqlPagingCompiler', $data.Expressions.EntityExpressionVisitor, 
     },
     VisitConstantExpression: function (expression, sqlBuilder) {
         sqlBuilder.addParameter(expression.value);
-        sqlBuilder.addText(SqlStatementBlocks.parameter);
+        sqlBuilder.addText($data.sqLite.SqlStatementBlocks.parameter);
     }
 });

--- a/Types/StorageProviders/SqLite/SqlProjectionCompiler.js
+++ b/Types/StorageProviders/SqLite/SqlProjectionCompiler.js
@@ -11,30 +11,30 @@ $C('$data.sqLite.SqlProjectionCompiler', $data.Expressions.EntityExpressionVisit
     VisitParametricQueryExpression: function (expression, sqlBuilder) {
         if (expression.expression instanceof $data.Expressions.EntityExpression) {
             this.VisitEntitySetExpression(sqlBuilder.sets[0], sqlBuilder);
-            sqlBuilder.addText("rowid AS " + this.anonymFiledPrefix + SqlStatementBlocks.rowIdName + ", ");
+            sqlBuilder.addText("rowid AS " + this.anonymFiledPrefix + $data.sqLite.SqlStatementBlocks.rowIdName + ", ");
             this.VisitEntityExpressionAsProjection(expression, sqlBuilder);
         }
         else if (expression.expression instanceof $data.Expressions.EntitySetExpression) {
             this.VisitEntitySetExpression(sqlBuilder.sets[0], sqlBuilder);
-            sqlBuilder.addText("rowid AS " + this.anonymFiledPrefix + SqlStatementBlocks.rowIdName + ", ");
+            sqlBuilder.addText("rowid AS " + this.anonymFiledPrefix + $data.sqLite.SqlStatementBlocks.rowIdName + ", ");
             this.anonymFiledPrefix = sqlBuilder.getExpressionAlias(expression.expression) + '__'
             this.MappedFullEntitySet(expression.expression, sqlBuilder);
         }
         else if (expression.expression instanceof $data.Expressions.ObjectLiteralExpression) {
             this.VisitEntitySetExpression(sqlBuilder.sets[0], sqlBuilder);
-            sqlBuilder.addText("rowid AS " + this.anonymFiledPrefix + SqlStatementBlocks.rowIdName + ", ");
+            sqlBuilder.addText("rowid AS " + this.anonymFiledPrefix + $data.sqLite.SqlStatementBlocks.rowIdName + ", ");
             this.Visit(expression.expression, sqlBuilder);
         } else {
             this.VisitEntitySetExpression(sqlBuilder.sets[0], sqlBuilder);
             sqlBuilder.addText("rowid");
-            sqlBuilder.addText(SqlStatementBlocks.as);
-            sqlBuilder.addText(SqlStatementBlocks.rowIdName);
+            sqlBuilder.addText($data.sqLite.SqlStatementBlocks.as);
+            sqlBuilder.addText($data.sqLite.SqlStatementBlocks.rowIdName);
             sqlBuilder.addText(', ');
-            sqlBuilder.addKeyField(SqlStatementBlocks.rowIdName);
+            sqlBuilder.addKeyField($data.sqLite.SqlStatementBlocks.rowIdName);
             this.Visit(expression.expression, sqlBuilder);
             if (!(expression.expression instanceof $data.Expressions.ComplexTypeExpression)) {
-                sqlBuilder.addText(SqlStatementBlocks.as);
-                sqlBuilder.addText(SqlStatementBlocks.scalarFieldName);
+                sqlBuilder.addText($data.sqLite.SqlStatementBlocks.as);
+                sqlBuilder.addText($data.sqLite.SqlStatementBlocks.scalarFieldName);
             }
         }
     },
@@ -48,15 +48,15 @@ $C('$data.sqLite.SqlProjectionCompiler', $data.Expressions.EntityExpressionVisit
 
         ee.storageModel.PhysicalType.memberDefinitions.getPublicMappedProperties().forEach(function (memberInfo, index) {
             if (index > 0) {
-                sqlBuilder.addText(SqlStatementBlocks.valueSeparator);
+                sqlBuilder.addText($data.sqLite.SqlStatementBlocks.valueSeparator);
             }
 
             var fieldName = localPrefix + memberInfo.name;
 
             sqlBuilder.addText(alias);
-            sqlBuilder.addText(SqlStatementBlocks.nameSeparator);
+            sqlBuilder.addText($data.sqLite.SqlStatementBlocks.nameSeparator);
             sqlBuilder.addText(memberInfo.name);
-            sqlBuilder.addText(SqlStatementBlocks.as);
+            sqlBuilder.addText($data.sqLite.SqlStatementBlocks.as);
             sqlBuilder.addText(fieldName);
         }, this);
     },
@@ -70,7 +70,7 @@ $C('$data.sqLite.SqlProjectionCompiler', $data.Expressions.EntityExpressionVisit
         var opName = opDefinition.mapTo || opDefinition.name;
 
         sqlBuilder.addText(opName);
-        sqlBuilder.addText(SqlStatementBlocks.beginGroup);
+        sqlBuilder.addText($data.sqLite.SqlStatementBlocks.beginGroup);
         if (opName === "like") {
             var builder = $data.sqLite.SqlBuilder.create();
             this.Visit(expression.parameters[0], builder);
@@ -92,20 +92,20 @@ $C('$data.sqLite.SqlProjectionCompiler', $data.Expressions.EntityExpressionVisit
             }, this);
         };
 
-        sqlBuilder.addText(SqlStatementBlocks.endGroup);
+        sqlBuilder.addText($data.sqLite.SqlStatementBlocks.endGroup);
     },
 
     VisitUnaryExpression: function (expression, sqlBuilder) {
         /// <param name="expression" type="$data.Expressions.SimpleBinaryExpression"></param>
         /// <param name="sqlBuilder" type="$data.sqLite.SqlBuilder"></param>
         sqlBuilder.addText(expression.resolution.mapTo);
-        sqlBuilder.addText(SqlStatementBlocks.beginGroup);
+        sqlBuilder.addText($data.sqLite.SqlStatementBlocks.beginGroup);
         this.Visit(expression.operand, sqlBuilder);
-        sqlBuilder.addText(SqlStatementBlocks.endGroup);
+        sqlBuilder.addText($data.sqLite.SqlStatementBlocks.endGroup);
     },
 
     VisitSimpleBinaryExpression: function (expression, sqlBuilder) {
-        sqlBuilder.addText(SqlStatementBlocks.beginGroup);
+        sqlBuilder.addText($data.sqLite.SqlStatementBlocks.beginGroup);
         this.Visit(expression.left, sqlBuilder);
         var self = this;
         sqlBuilder.addText(" " + expression.resolution.mapTo + " ");
@@ -114,13 +114,13 @@ $C('$data.sqLite.SqlProjectionCompiler', $data.Expressions.EntityExpressionVisit
             Guard.requireType("expression.right", expression.right, $data.Expressions.ConstantExpression);
             var set = expression.right.value;
             if (set instanceof Array) {
-                sqlBuilder.addText(SqlStatementBlocks.beginGroup);
+                sqlBuilder.addText($data.sqLite.SqlStatementBlocks.beginGroup);
                 set.forEach(function (item, i) {
-                    if (i > 0) sqlBuilder.addText(SqlStatementBlocks.valueSeparator);
+                    if (i > 0) sqlBuilder.addText($data.sqLite.SqlStatementBlocks.valueSeparator);
                     var c = Container.createConstantExpression(item);
                     self.Visit(c, sqlBuilder);
                 });
-                sqlBuilder.addText(SqlStatementBlocks.endGroup);
+                sqlBuilder.addText($data.sqLite.SqlStatementBlocks.endGroup);
             } else if (set instanceof $data.Queryable) {
                 Guard.raise("not yet... but coming");
             } else {
@@ -129,13 +129,13 @@ $C('$data.sqLite.SqlProjectionCompiler', $data.Expressions.EntityExpressionVisit
         } else {
             this.Visit(expression.right, sqlBuilder);
         }
-        sqlBuilder.addText(SqlStatementBlocks.endGroup);
+        sqlBuilder.addText($data.sqLite.SqlStatementBlocks.endGroup);
     },
 
     VisitConstantExpression: function (expression, sqlBuilder) {
         var value = expression.value;
         sqlBuilder.addParameter(value);
-        sqlBuilder.addText(SqlStatementBlocks.parameter);
+        sqlBuilder.addText($data.sqLite.SqlStatementBlocks.parameter);
     },
 
     VisitEntityFieldExpression: function (expression, sqlBuilder) {
@@ -146,7 +146,7 @@ $C('$data.sqLite.SqlProjectionCompiler', $data.Expressions.EntityExpressionVisit
             if (!member) { Guard.raise(new Exception('Compiler error! ComplexType does not contain ' + expression.source.selector.memberName + ' property!')); return;}
 
             sqlBuilder.addText(alias);
-            sqlBuilder.addText(SqlStatementBlocks.nameSeparator);
+            sqlBuilder.addText($data.sqLite.SqlStatementBlocks.nameSeparator);
             sqlBuilder.addText(member[storageModel.From]);
         }
         else {
@@ -159,7 +159,7 @@ $C('$data.sqLite.SqlProjectionCompiler', $data.Expressions.EntityExpressionVisit
     VisitEntitySetExpression: function (expression, sqlBuilder) {
         var alias = sqlBuilder.getExpressionAlias(expression);
         sqlBuilder.addText(alias);
-        sqlBuilder.addText(SqlStatementBlocks.nameSeparator);
+        sqlBuilder.addText($data.sqLite.SqlStatementBlocks.nameSeparator);
     },
 
     VisitComplexTypeExpression: function (expression, sqlBuilder) {
@@ -167,12 +167,12 @@ $C('$data.sqLite.SqlProjectionCompiler', $data.Expressions.EntityExpressionVisit
         var storageModel = expression.source.storageModel.ComplexTypes[expression.selector.memberName];
         storageModel.ReferentialConstraint.forEach(function (constrain, index) {
             if (index > 0) {
-                sqlBuilder.addText(SqlStatementBlocks.valueSeparator);
+                sqlBuilder.addText($data.sqLite.SqlStatementBlocks.valueSeparator);
             }
             sqlBuilder.addText(alias);
-            sqlBuilder.addText(SqlStatementBlocks.nameSeparator);
+            sqlBuilder.addText($data.sqLite.SqlStatementBlocks.nameSeparator);
             sqlBuilder.addText(constrain[storageModel.From]);
-            sqlBuilder.addText(SqlStatementBlocks.as);
+            sqlBuilder.addText($data.sqLite.SqlStatementBlocks.as);
             sqlBuilder.addText(this.anonymFiledPrefix + constrain[storageModel.To]);
         }, this);
     },
@@ -187,7 +187,7 @@ $C('$data.sqLite.SqlProjectionCompiler', $data.Expressions.EntityExpressionVisit
         var membersNumber = expression.members.length;
         for (var i = 0; i < membersNumber; i++) {
             if (i != 0) {
-                sqlBuilder.addText(SqlStatementBlocks.valueSeparator);
+                sqlBuilder.addText($data.sqLite.SqlStatementBlocks.valueSeparator);
             }
             this.Visit(expression.members[i], sqlBuilder);
         }
@@ -198,12 +198,12 @@ $C('$data.sqLite.SqlProjectionCompiler', $data.Expressions.EntityExpressionVisit
         properties.forEach(function (prop, index) {
             if (!prop.association) {
                 if (index > 0) {
-                    sqlBuilder.addText(SqlStatementBlocks.valueSeparator);
+                    sqlBuilder.addText($data.sqLite.SqlStatementBlocks.valueSeparator);
                 }
                 sqlBuilder.addText(alias);
-                sqlBuilder.addText(SqlStatementBlocks.nameSeparator);
+                sqlBuilder.addText($data.sqLite.SqlStatementBlocks.nameSeparator);
                 sqlBuilder.addText(prop.name);
-                sqlBuilder.addText(SqlStatementBlocks.as);
+                sqlBuilder.addText($data.sqLite.SqlStatementBlocks.as);
                 sqlBuilder.addText(this.anonymFiledPrefix + prop.name);
             }
         }, this);
@@ -234,7 +234,7 @@ $C('$data.sqLite.SqlProjectionCompiler', $data.Expressions.EntityExpressionVisit
             this.anonymFiledPrefix = tmpPrefix;
 
             if (!(expression.expression instanceof $data.Expressions.ObjectLiteralExpression) && !(expression.expression instanceof $data.Expressions.ComplexTypeExpression) && !(expression.expression instanceof $data.Expressions.EntitySetExpression)) {
-                sqlBuilder.addText(SqlStatementBlocks.as);
+                sqlBuilder.addText($data.sqLite.SqlStatementBlocks.as);
                 sqlBuilder.addText(this.anonymFiledPrefix + expression.fieldName);
             }
         }


### PR DESCRIPTION
- bugfix: local variable 'SqlStatementBlocks' can't be accessed from other node modules
  (it's not needed if you change the build script to concatenatejs files as in the client side)
- bugfix: avoid sql query colision in a sqLite connection (useful on client side also)

TODO : context.saveChanges couldn't handle parallel requests
