### PR TITLE
Fixed DI bugs in angularjs module

### DIFF
--- a/JayDataModules/angular.js
+++ b/JayDataModules/angular.js
@@ -27,9 +27,9 @@ var _getCacheKey = function (query) {
     return hash;
 }
 
-angular.module('jaydata', ['ng', function ($provide) {
+angular.module('jaydata', ['ng', ['$provide', function ($provide) {
 
-    $provide.factory('$data', function ($rootScope, $q) {
+    $provide.factory('$data', ['$rootScope', '$q', function ($rootScope, $q) {
         var cache = {};
 
         $data.Entity.prototype.hasOwnProperty = function (propName) {
@@ -230,7 +230,7 @@ angular.module('jaydata', ['ng', function ($provide) {
             return d.promise;
         }
         return $data;
-    });
-}]);
+    }]);
+}]]);
 
 })();


### PR DESCRIPTION
Fixed DI bugs. Currently the 'simple' syntax for DI is being used, but this is not 'minifier proof'. This is why angular.min.js is currently broken. See [the documentation](http://docs.angularjs.org/guide/di) for more info.
This pull request fixes that.
