### PR TITLE
Fixed the setting of serverPaging, serverFiltering and serverSorting

### DIFF
--- a/JayDataModules/kendo.js
+++ b/JayDataModules/kendo.js
@@ -690,9 +690,9 @@
         ds = ds || {};
         //unless user explicitly opts out server side logic
         //we just force it.
-        ds.serverPaging = ds.serverPaging || true;
-        ds.serverFiltering = ds.serverFiltering || true;
-        ds.serverSorting = ds.serverSorting || true;
+        ds.serverPaging = ds.serverPaging !== false;
+        ds.serverFiltering = ds.serverFiltering !== false;
+        ds.serverSorting = ds.serverSorting !== false;
         ds.pageSize = ds.pageSize === undefined ? $data.kendo.defaultPageSize : ds.pageSize;
 
         var TransportClass = self.asKendoRemoteTransportClass(model);


### PR DESCRIPTION
the options serverPaging, serverFiltering and serverSorting for the asKendoDataSource() function are evaluating always to true in the current code.
false || true == true
so 
ds.serverPaging = ds.serverPaging || true;

My changes will now evaluate to true for everything else than a value of false, so asKendoDataSource({ serverFiltering: false }) will now work as expected.
