### PR TITLE
override of "valueOf" removed (TypeScript 0.9.5)

### DIFF
--- a/jaydata.d.ts
+++ b/jaydata.d.ts
@@ -8,7 +8,6 @@ declare module $data {
             (handler: (args: T) => void ): IPromise<any>;
             (handler: (args: T) => any): IPromise<any>;
         };
-        valueOf(): any;
     }
 
     export class Base implements Object {


### PR DESCRIPTION
Interface '$data.IPromise<T>' cannot extend interface 'Object':
    Types of property 'valueOf' of types 'IPromise<T>' and 'Object' are incompatible:
Call signatures of types '() => any' and '() => Object' are incompatible.
