### PR TITLE
Update CodeParser.js

### DIFF
--- a/Types/Expressions/CodeParser.js
+++ b/Types/Expressions/CodeParser.js
@@ -30,6 +30,7 @@ $C('$data.Expressions.CodeParser', null, null, {
         };
         ///<var name="AST" type="Date" />
         
+        code = code.replace(/("use strict";)/gi, '');
         //console.log(code.toString());
         if ($data.Acorn){
             //console.log('using acorn.js');


### PR DESCRIPTION
In strict modus Firefox adds "use strict"; to functions. So the parseBuilder will fail cause the first statement in the body is "use strict".

This is probably not the best solution, but it will do the trick.
