### PR TITLE
Fixed deep property navigation in kendo ds filter

### DIFF
--- a/JayDataModules/kendo.js
+++ b/JayDataModules/kendo.js
@@ -483,7 +483,13 @@
                                     $data.Trace.log('unknown operator', f.operator);
                                     break;
                             }
-                            thisArg[f.field] = f.value;
+                            
+							f.field.split('.').forEach(function (fp, index, arr) {
+                                if (index < arr.length - 1)
+                                    this.ctx = (this.ctx[fp] = this.ctx[fp] || {});
+                                else
+                                    this.ctx[fp] = f.value
+                            }, { ctx: thisArg })
                         })
                         q = q.filter(filter, thisArg);
                     }

--- a/JayDataModules/kendo.js
+++ b/JayDataModules/kendo.js
@@ -235,7 +235,7 @@
                         if (propNameParts.length == 1) {
                             var propValue = e.value;
                             if (!jayInstance.changeFromJay) {
-                                propValue = propValue.innerInstance ? propValue.innerInstance() : propValue;
+                                propValue = (propValue && propValue.innerInstance) ? propValue.innerInstance() : propValue;
                                 jayInstance[propName] = propValue;
                                 if (options && options.autoSave) {
                                     jayInstance.save();

--- a/Scripts/acorn.js
+++ b/Scripts/acorn.js
@@ -1009,7 +1009,7 @@
 
   function isUseStrict(stmt) {
     return options.ecmaVersion >= 5 && stmt.type === "ExpressionStatement" &&
-      stmt.expression.type === "Literal" && stmt.expression.value === "use strict";
+      stmt.expression.type === "Literal" && stmt.expression.value === ("use " + "strict");
   }
 
   // Predicate that tests whether the next token is of the given

--- a/Types/EntityContext.js
+++ b/Types/EntityContext.js
@@ -992,7 +992,7 @@ $data.Class.define('$data.EntityContext', null, null,
                                 //} else {
                                 //    data.entityState = $data.EntityState.Added;
                                 //}
-                                this.discoverDependentItemEntityState(data);
+                                this.discoverDependentItemEntityState(data, entityCachedItem.data);
                             }
                             if (additionalEntities.indexOf(data) == -1) {
                                 additionalEntities.push(data);
@@ -1265,8 +1265,10 @@ $data.Class.define('$data.EntityContext', null, null,
 
         return pHandlerResult;
     },
-    discoverDependentItemEntityState: function (data) {
-        if (data.storeToken === this.storeToken) {
+    discoverDependentItemEntityState: function (data, dependentOn) {
+		if (dependentOn.entityState === $data.EntityState.Deleted) {
+			data.entityState = $data.EntityState.Unchanged;
+		} else if (data.storeToken === this.storeToken) {
             data.entityState = $data.EntityState.Modified;
         } else if (data.storeToken && this.storeToken && data.storeToken.typeName === this.storeToken.typeName && JSON.stringify(data.storeToken.args) === JSON.stringify(this.storeToken.args)) {
             data.entityState = $data.EntityState.Modified;


### PR DESCRIPTION
Filters like { field: 'Very.Deep.Path.To.A.Field', operator: 'contains',
value: 'foo' } were not working
