### PR TITLE
Fix bower package name and version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "jaydata",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "homepage": "http://jaydata.org",
   "authors": ["Hajnalka Battancs <hajnalka.battancs@jaydata.org>", "Dániel József", "János Roden", "László Horváth", "Peter Nochta <peter.nochta@jaydata.org>",
      "Péter Zentai <peter.zentai@jaydata.org>", "Róbert Bónay <robert.bonay@jaydata.org>", "Szabolcs Czinege", "Viktor Borza <viktor.borza@jaydata.org>", "Viktor Lázár <viktor.lazar@jaydata.org>",

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "jaydata",
-  "version": "1.3.6",
+  "version": "1.5.5",
   "homepage": "http://jaydata.org",
   "authors": ["Hajnalka Battancs <hajnalka.battancs@jaydata.org>", "Dániel József", "János Roden", "László Horváth", "Peter Nochta <peter.nochta@jaydata.org>",
      "Péter Zentai <peter.zentai@jaydata.org>", "Róbert Bónay <robert.bonay@jaydata.org>", "Szabolcs Czinege", "Viktor Borza <viktor.borza@jaydata.org>", "Viktor Lázár <viktor.lazar@jaydata.org>",

--- a/bower.json
+++ b/bower.json
@@ -10,5 +10,8 @@
   "keywords": ["mobile data", "javascipt data", "local storage", "mobile platform", "html5", "html5 application", "html5 applications", "html5 local", "html5 local storage", "html5 mobile", "crossplatform mobile developement", "opensource mobile", "opensource data library", "html5 library", "hybrid mobile", "nodejs data",
     "jadata","odata", "web api", "kendo ui", "sencha touch", "websql", "sqlite", "mongodb"
   ],
-  "license": "MIT"
+  "license": "MIT",
+  "ignore": [],
+  "dependencies": {},
+  "devDependencies": {}
 }

--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "JayData",
+  "name": "jaydata",
   "version": "1.3.5",
   "homepage": "http://jaydata.org",
   "authors": ["Hajnalka Battancs <hajnalka.battancs@jaydata.org>", "Dániel József", "János Roden", "László Horváth", "Peter Nochta <peter.nochta@jaydata.org>",


### PR DESCRIPTION
fixes #151, #152 and #201
- [BowerJson Spec](https://github.com/bower/spec/blob/master/json.md#name) recommends (not enforces) all letters in a package name to be lowercase. The package is already registred as such.
- Package Version in `bower.json` differed from release version (will need force-push of the release tag)
- add `ignore` property to `bower.json`
#### Warnings that Bower throws installing the `jaydata` package

```
bower jaydata#~1.3.6   mismatch Version declared in the json (1.3.5) is different than the resolved one (1.3.6)
bower jaydata#~1.3.6   invalid-meta JayData is missing "ignore" entry in bower.json
bower jaydata#~1.3.6   resolved git://github.com/jaydata/jaydata.git#1.3.6
```
