### PR TITLE
OData v4 $select, $expand, and batch save fixes

### DIFF
--- a/src/Types/StorageProviders/oData/oDataCompiler.js
+++ b/src/Types/StorageProviders/oData/oDataCompiler.js
@@ -74,11 +74,10 @@ $C('$data.storageProviders.oData.oDataCompiler', $data.Expressions.EntityExpress
     VisitIncludeExpression: function (expression, context) {
         this.Visit(expression.source, context);
         if (!context['$select']) {
-            if (context['$expand']) { context['$expand'] += ','; } else { context['$expand'] = ''; }
-            context['$expand'] += expression.selector.value.replace(/\./g, '/');
-
             this.includes = this.includes || [];
             var includeFragment = expression.selector.value.split('.');
+            if (context['$expand']) { context['$expand'] += ','; } else { context['$expand'] = ''; }
+            context['$expand'] += includeFragment.map(function(x, i) { return (i == 0 ? x : '$expand=' + x) }).join('(') + Array(includeFragment.length).join(')');	
             var tempData = null;
             var storageModel = this.mainEntitySet.entityContext._storageModel.getStorageModel(this.mainEntitySet.createNew);
             for (var i = 0; i < includeFragment.length; i++) {

--- a/src/Types/StorageProviders/oData/oDataProvider.js
+++ b/src/Types/StorageProviders/oData/oDataProvider.js
@@ -378,13 +378,13 @@ $C('$data.storageProviders.oData.oDataProvider', $data.StorageProviderBase, null
             this._saveRestMany(independentBlocks, callBack);
         }
     },
-    _buildSaveData: function(independentBlocks, convertedItem) {
+    _buildSaveData: function(independentBlocks, convertedItem, batch) {
         var requests = [];
         for (var index = 0; index < independentBlocks.length; index++) {
             var requestPart = []
             for (var i = 0; i < independentBlocks[index].length; i++) {
                 var request = {
-                    requestUri: this.providerConfiguration.oDataServiceHost + '/'
+                    requestUri: batch ? '' : this.providerConfiguration.oDataServiceHost + '/'
                 };
                 convertedItem.add(independentBlocks[index][i].data, request);
                 
@@ -593,7 +593,7 @@ $C('$data.storageProviders.oData.oDataProvider', $data.StorageProviderBase, null
         var batchRequests = [];
         //var maxContentId = 0;
         
-        var requestObjects = this._buildSaveData(independentBlocks, convertedItem)
+        var requestObjects = this._buildSaveData(independentBlocks, convertedItem, true)
         for (var index = 0; index < requestObjects.length; index++) {
             for (var i = 0; i < requestObjects[index].length; i++) {
                 var request = requestObjects[index][i]


### PR DESCRIPTION
batch save was incorrectly appending this.providerConfiguration.oDataServiceHost + '/' to each item in the batch.

$select and $expand had not yet been converted to OData v4 and thus only worked on level 0 items.

$select
http://docs.oasis-open.org/odata/odata/v4.0/errata02/os/complete/part1-protocol/odata-v4.0-errata02-os-part1-protocol-complete.html#_Toc406398297

$expand
http://docs.oasis-open.org/odata/odata/v4.0/errata02/os/complete/part1-protocol/odata-v4.0-errata02-os-part1-protocol-complete.html#_Toc406398298
