### PR TITLE
Bugfix: fixes #242 - when setting a property to null, it will fail

### DIFF
--- a/src/JayDataModules/kendo.js
+++ b/src/JayDataModules/kendo.js
@@ -241,7 +241,7 @@ import kendo from 'kendo'
                         if (propNameParts.length == 1) {
                             var propValue = e.value;
                             if (!jayInstance.changeFromJay) {
-                                propValue = propValue.innerInstance ? propValue.innerInstance() : propValue;
+                                propValue = propValue && propValue.innerInstance ? propValue.innerInstance() : propValue;
                                 jayInstance[propName] = propValue;
                                 if (options && options.autoSave) {
                                     jayInstance.save();


### PR DESCRIPTION
This fixes #242.

In the current state, when trying to set a property to a null value, this will fail, as
`propValue` is `null`, and the check for `propValue.innerInstance` will fail.

So I added an additional check to see if `propVale` evals to truthy.
