### PR TITLE
Fixed several problems in kendo.js module + inMemory module + jay data model binder

### DIFF
--- a/src/JayDataModules/inMemory.js
+++ b/src/JayDataModules/inMemory.js
@@ -2,18 +2,21 @@ import $data, { $C, Guard, Container, Exception, MemberDefinition } from 'jaydat
 
 (function ($data) {
 
-    $data.Array.prototype.toQueryable = function () {
-        if (this.length > 0) {
-            var firtsItem = this[0];
-            var type = Container.resolveType(Container.getTypeName(firtsItem));
-
-            if (!type.isAssignableTo || !type.isAssignableTo($data.Entity))
-                Guard.raise(new Exception("Type '" + Container.resolveName(type) + "' is not subclass of $data.Entity", "Not supported", type));
-
-            for (var i = 0; i < this.length; i++) {
-                Guard.requireType('array item check', this[i], type);
+    $data.Array.prototype.toQueryable = function (type) {
+        if (type == null) {
+            if(this.length > 0){
+                var firtsItem = this[0];
+                type = _core.Container.resolveType(_core.Container.getTypeName(firtsItem));
             }
+            else{
+                _core.Guard.raise(new _core.Exception("You may not call toQueryable on empty array. Either call toQueryable on non-empty array or pass entity type to toQueryable method"));
+            }
+        }
 
+        if (!type.isAssignableTo || !type.isAssignableTo($data.Entity)) _core.Guard.raise(new _core.Exception("Type '" + _core.Container.resolveName(type) + "' is not subclass of $data.Entity", "Not supported", type));
+
+        for (var i = 0; i < this.length; i++) {
+            _core.Guard.requireType('array item check', this[i], type);
         }
 
         var typeName = 'inMemoryArray_' + type.name;

--- a/src/Types/ModelBinder.js
+++ b/src/Types/ModelBinder.js
@@ -55,6 +55,11 @@ $data.Class.define('$data.ModelBinder', null, null, {
                 meta.$selector = [meta.$selector];
             }
 
+            context.src += 'if (di === null){';
+            if (context.iter) context.src += context.iter + ' = null;';
+            context.src += 'return null;';
+            context.src += '}';
+
             for (var i = 0; i < meta.$selector.length; i++) {
                 var selector = meta.$selector[i].replace('json:', '');
                 context.src += 'if(';
@@ -64,11 +69,6 @@ $data.Class.define('$data.ModelBinder', null, null, {
                 }
                 context.src += '){di = di["' + path.join('"]["') + '"];}' + (i < meta.$selector.length - 1 ? 'else ' : '');
             }
-
-            context.src += 'if (di === null){';
-            if (context.iter) context.src += context.iter + ' = null;';
-            context.src += 'return null;';
-            context.src += '}';
         }
     },
 


### PR DESCRIPTION
1. Ability to call toQueryable method on empty array by passing type to that as a parameter.
   type will be an optional parameter, if not passed, it will be detected from first item of array as like as before. So this is not a breaking change.
   I've added an exception in case when no type is provided and array itself is empty.
2. Better jayData filter creation from kendo data source filter. Now it supports ignoreCase, and filters like this will work { logic: 'or' , filters: [ {field:'FirstName' , op: 'eq' , value: 'A'} , {field:'FirstName' , op: 'eq' , value: 'B'} ] }
3. if (di === null){ return null; } was developed after usages of "di". I've moved that code to top.

Thanks in advance.
