### PR TITLE
Don't initialize empty strings with null in validation

### DIFF
--- a/src/Types/EntityContext.js
+++ b/src/Types/EntityContext.js
@@ -1387,7 +1387,7 @@ $data.Class.define('$data.EntityContext', null, null,
                     var memDef = entity.data.getType().memberDefinitions.getPublicMappedProperties()[j];
 
                     var memDefType = Container.resolveType(memDef.type);
-                    if (memDef.required && !memDef.computed && !entity.data[memDef.name] && !memDef.isDependentProperty) {
+                    if (memDef.required && !memDef.computed && !entity.data[memDef.name] && entity.data[memDef.name] !== "" && !memDef.isDependentProperty) {
                         switch (memDefType) {
                             case $data.String:
                             case $data.Number:


### PR DESCRIPTION
This PR fixes issue #276 

A brief summary: During validation of required properties, jaydata does not recognize the empty string `""` as a value and will call `.getDefault()` to create an initial value for that property. This will overwrite the empty string with `null`, which is not correct - especially for properties whose schema have a `nullable: false` annotation.

A special JS "feature" conceals this behaviour: ` !entity.data[memDef.name]` will evaluate to `true` for the empty string - because `!""` evaluates to true. However, I think the original author of that line only intended to check for `undefined` and `null`. So I added one more check to see if the property is the empty string, and only if this is not the case the property is overriden with the default value.