### PR TITLE
Recursive Complex Types

### DIFF
--- a/src/Types/QueryBuilder.js
+++ b/src/Types/QueryBuilder.js
@@ -46,7 +46,10 @@ $C('$data.queryBuilder', null, null, {
             this.modelBinderConfig['$keys'] = new Array();
         }
         this.modelBinderConfig['$keys'].push(name);
-    }
+    },
+    stackContainsType: function(elementType) {
+        return this._binderConfigPropertyStack.map(p => p.$type).indexOf(elementType) >= 0;
+    },
 });
 
 export default $data

--- a/src/Types/StorageProviders/modelBinderConfigCompiler.js
+++ b/src/Types/StorageProviders/modelBinderConfigCompiler.js
@@ -183,6 +183,9 @@ $C('$data.modelBinder.ModelBinderConfigCompiler', $data.Expressions.EntityExpres
     _addPropertyToModelBinderConfig: function (elementType, builder) {
         var storageModel = this._query.context._storageModel.getStorageModel(elementType);
         if (elementType.memberDefinitions) {
+            if (builder.stackContainsType(elementType)) {
+                return;
+            }
             var memberDefinitions = this._inheritanceMemberDefinitions(elementType, elementType.memberDefinitions.getPublicMappedProperties());
             memberDefinitions.forEach(function (prop) {
                 if ((!storageModel) || (storageModel && !storageModel.Associations[prop.name] && !storageModel.ComplexTypes[prop.name])) {


### PR DESCRIPTION
Deal with recursive data types in the model binder config compiler and query builder.  If the type is already on the query builder stack, then skip it.